### PR TITLE
Allow to choose if enable edit, insert and update separately

### DIFF
--- a/DBTableEditor.class.php
+++ b/DBTableEditor.class.php
@@ -78,7 +78,7 @@ class DBTE_DataTable {
    */
 class DBTableEditor {
   var $table, $title, $sql, $dataFn, $id, $data, $cap, $jsFile, 
-    $noedit, $editcap, $noedit_columns, $hide_columns, $default_values,
+    $noedit, $nodelete, $noinsert, $editcap, $noedit_columns, $hide_columns, $default_values,
       $columnFilters, $columnNameMap, $save_cb, $insert_cb, $update_cb, $delete_cb,
       $id_column, $auto_date, $async_data;
   function __construct($args=null){
@@ -87,6 +87,8 @@ class DBTableEditor {
     if(!$this->id) $this->id = $this->table;
     if(!$this->title) $this->title = $this->table;
     if(!$this->id_column) $this->id_column = 'id';
+    if(is_null($this->nodelete)) $this->nodelete = $this->noedit;
+    if(is_null($this->noinsert)) $this->noinsert = $this->noedit;
     if(!isset($args['auto_date'])) $this->auto_date=true;
   }
   /*

--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ This supports `wp_parse_args` style arguments.
  ** ex: `editcap=>"edit_others_posts"`
  * `noedit`: turns off the editing abilities (same as editcap=nosuchcapability)
  ** ex: `noedit=>true`
+ * `nodelete`: turns off the deleting abilities (Default: value of noedit argument)
+  ** ex: `nodelete=>true`
+ * `noinsert`: turns off the inserting abilities (Default: value of noedit argument)
+   ** ex: `noinsert=>true`
  * `columnFilters`: Default column filters, this is an array of column->val
    to be applied as default column fitlers when the page is loaded
  ** ex: `columnFilters=>Array("Year"=>"2017")`

--- a/README.txt
+++ b/README.txt
@@ -69,6 +69,10 @@ This supports `wp_parse_args` style arguments.
   * ex: `editcap=>"edit_others_posts"`
  * `noedit`: turns off the editing abilities (same as editcap=nosuchcapability)
   * ex: `noedit=>true`
+ * `nodelete`: turns off the deleting abilities (Default: value of noedit argument)
+  * ex: `nodelete=>true`
+ * `noinsert`: turns off the inserting abilities (Default: value of noedit argument)
+  * ex: `noinsert=>true`
  * `columnFilters`: Default column filters, this is an array of column->val
    to be applied as default column fitlers when the page is loaded
   * ex: `columnFilters=>Array("Year"=>"2017")`

--- a/assets/db-table-editor.js
+++ b/assets/db-table-editor.js
@@ -109,7 +109,11 @@ DBTableEditor.save = function(){
   }
   //console.log('trying to save: ', toSave);
   var cols = DBTableEditor.data.columns.map(function(c){return c.originalName;});
-  cols.shift(); // remove buttons
+
+  if(!DBTableEditor.nodelete) {
+    cols.shift(); // remove buttons
+  }
+
   var toSend = JSON.stringify({
     modifiedIdxs:toSave.map(function(it){return it.modifiedIdxs;}),
     columns:cols,
@@ -414,7 +418,7 @@ DBTableEditor.afterLoadData = function(){
     r.id = rid;
   }
   // init columns
-  if(!DBTableEditor.noedit){
+  if(!DBTableEditor.nodelete){
     //console.log('Adding buttons column', DBTableEditor.buttonColumnWidth);
     columns.unshift({id: 'buttons',
                      formatter:DBTableEditor.rowButtonFormatter,
@@ -426,7 +430,7 @@ DBTableEditor.afterLoadData = function(){
     enableCellNavigation: true,
     enableColumnReorder: true,
     editable: !DBTableEditor.noedit,
-    enableAddRow: !DBTableEditor.noedit,
+    enableAddRow: !DBTableEditor.noinsert,
     multiColumnSort:true,
     autoEdit:false,
     editCommandHandler: DBTableEditor.queueAndExecuteCommand,

--- a/db-table-editor.php
+++ b/db-table-editor.php
@@ -215,6 +215,8 @@ function dbte_render($id=null){
   }
   $base = plugins_url('wp-db-table-editor');
   $noedit = $cur->noedit;
+  $nodelete = $cur->nodelete;
+  $noinsert = $cur->noinsert;
   $pendingSaveCnt = "";
   $pendingSaveHeader = "";
   $buttons="";
@@ -222,7 +224,8 @@ function dbte_render($id=null){
     $noedit = true;
     $cur->noedit = true;
   }
-  if( !$noedit ){
+
+  if( !$noedit || !$nodelete || !$noinsert){
     $pendingSaveCnt = '<span class="pending-save-count">0</span>';
     $pendingSaveHeader = '<div class="pending-save-header">'.sprintf(__('There are %s unsaved changes', 'wp-db-table-editor'), $pendingSaveCnt).'</div>';
     $saveButtonLabel = sprintf(__('Save %s Changes', 'wp-db-table-editor'), $pendingSaveCnt);


### PR DESCRIPTION
Hi,
i made some edits for allowing to choose if enable edit, insert and update separately. For doing this i added two extra configuration options:
- nodelete
- noinsert

Their default value will be the same of "noedit". 

You can also enable inserting or deleting and, in the same time, disabling the editing of the existing values using the following configuration:
`'noedit' => true,
'nodelete'        => false,
'noinsert'        => false`

